### PR TITLE
Remove file:// prefix and use relative paths in less plugin.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "steal-less",
-	"version": "0.0.1",
+	"version": "0.2.1",
 	"authors": [
 		"Bitovi"
 	],

--- a/less.js
+++ b/less.js
@@ -81,8 +81,10 @@ if (lessEngine.FileManager) {
 		// collect locate promises
 		file.contents.replace(self.PATTERN, function (whole, path, index) {
 			promises.push(self.locate(path, file.filename.replace(loader.baseURL, '')).then(function(filename) {
+				filename = filename.replace(/^file\:/,"");
+
 				return {
-					str: filename.replace(file._directory, ''),
+					str: relative(file._directory, filename),
 					loc: index,
 					del: whole.length
 				}
@@ -132,3 +134,20 @@ if (lessEngine.FileManager) {
 		}
 	};
 }
+
+var relative = function(base, path){
+	var uriParts = path.split("/"),
+		baseParts = base.split("/"),
+		result = [];
+
+	while ( uriParts.length && baseParts.length && uriParts[0] == baseParts[0] ) {
+		uriParts.shift();
+		baseParts.shift();
+	}
+
+	for(var i = 0 ; i< baseParts.length-1; i++) {
+		result.push("../");
+	}
+
+	return result.join("") + uriParts.join("/");
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name":"steal-less",
-	"version":"0.2.0",
+	"version":"0.2.1",
 	"description":"less plugin for StealJS and SystemJS",
 	"main":"css.js",
 	"scripts":{

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"devDependencies":{
 		"bower":"^1.4.1",
 		"grunt": "^0.4.5",
-		"steal":"stealjs/steal#605-locate-path-schemes",
+		"steal":"0.15.0",
 		"testee": "^0.2.5",
 		"steal-css": "^0.0.2",
 		"systemjs":"bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542"


### PR DESCRIPTION
More robustly fix bug where 'file://' prefix was on paths written into less imports during a steal-tools build. Now also creates relative paths including '../'.