### PR TITLE
Locate: normalize any relative pathing in importer file path. 

### DIFF
--- a/less.js
+++ b/less.js
@@ -105,7 +105,7 @@ if (lessEngine.FileManager) {
 		var self = this,
 			_callback = callback,
 			path = (currentDirectory + filename),
-			directory = path.substring(0, path.lastIndexOf('/')+1),
+			directory = normalizePath(path.substring(0, path.lastIndexOf('/')+1)),
 			promise;
 
 		callback = function(err, file) {
@@ -135,6 +135,24 @@ if (lessEngine.FileManager) {
 	};
 }
 
+var normalizePath = function(path) {
+	var parts = path.split('/'),
+		normalized = [];
+
+	for (var i = 0 ; i< parts.length; i++) {
+		var part = parts[i];
+		if (part != '.') { // ignore './'
+			if (part == '..') { // remove part preceding '../'
+				normalized.pop();
+			} else {
+				normalized.push(part);
+			}
+		}
+	}
+	return normalized.join('/');
+};
+
+
 var relative = function(base, path){
 	var uriParts = path.split("/"),
 		baseParts = base.split("/"),
@@ -145,7 +163,7 @@ var relative = function(base, path){
 		baseParts.shift();
 	}
 
-	for(var i = 0 ; i< baseParts.length-1; i++) {
+	for (var i = 0 ; i < baseParts.length-1; i++) {
 		result.push("../");
 	}
 

--- a/test/less_tilde/dev.html
+++ b/test/less_tilde/dev.html
@@ -7,6 +7,7 @@
 	<div id='test-element'>ELMENT1</div>
 	<div id='test-element-2'>ELMENT2</div>
 	<div id='test-element-3'>ELMENT3</div>
+	<div id='test-element-4'>ELMENT4</div>
 	<script type="text/javascript"
 		src="../../node_modules/steal/steal.js"
 		data-config="../config.js" main="less_tilde/main">

--- a/test/less_tilde/libs/bootstrap/module_b.less
+++ b/test/less_tilde/libs/bootstrap/module_b.less
@@ -1,4 +1,4 @@
-@import 'locate://./module_c.less';
+@import 'locate://../module_c.less';
 
 .mixin-b {
   width: 20px;

--- a/test/less_tilde/libs/ext/module_d.less
+++ b/test/less_tilde/libs/ext/module_d.less
@@ -1,0 +1,3 @@
+#test-element-4 {
+	width: 1337px;
+}

--- a/test/less_tilde/libs/module_c.less
+++ b/test/less_tilde/libs/module_c.less
@@ -1,10 +1,12 @@
+@import 'locate://./ext/module_d.less';
+
 .mixin-c {
-	color: goldenrod;
+	height: 20px;
 }
 
 @imported-location: "locate://bootstrap/other.png";
 
-// works because less rewrites this url() path to be relative
+//works because less rewrites this url() path to be relative
 #test-element-3 {
 	background-image: url(@imported-location) !important;
 }

--- a/test/less_tilde/main.js
+++ b/test/less_tilde/main.js
@@ -16,8 +16,10 @@ var testImage = function(selector, cb){
 
 
 if(window.QUnit) {
-	QUnit.ok( $("#test-element").width(), 20);
-	QUnit.ok( $("#test-element").css('color'), 'goldenrod');
+	QUnit.equal( $("#test-element").width(), 20, 'applied mixin-b');
+	QUnit.equal( $("#test-element").height(), 20), 'applied mixin-c';
+	QUnit.equal( $('#test-element-4').width(), 1337, 'locate://\'ed resource from importer whose path includes "../"');
+
 	testImage("#test-element", function(err){
 		if(err){
 			QUnit.ok(false, err);


### PR DESCRIPTION
Fixes #14 

Normalize any relative pathing in importer file path before determining relative path of imported resource. Add new test for this, fix existing tests.