### PR TITLE
Adds includedDeps to metadata for less loads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "5.8"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function(grunt){
 			options: {
 				browsers: ["firefox"]
 			},
-			all: ["test/test.html"]
+			all: ["test/test.html", "test/unit.html"]
 		}
 	});
 

--- a/less.js
+++ b/less.js
@@ -40,6 +40,7 @@ exports.translate = function(load) {
 		var done = function(output) {
 			// Put the source map on metadata if one was created.
 			load.metadata.map = output.map;
+			load.metadata.includedDeps = output.imports || [];
 			resolve(output.css);
 		};
 
@@ -137,6 +138,8 @@ if (lessEngine.FileManager) {
 			pluginManager.addFileManager(new StealLessManager());
 		}
 	};
+
+	exports.StealLessManager = StealLessManager;
 }
 
 var normalizePath = function(path) {

--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
-	"name":"steal-less",
-	"version":"0.2.2",
-	"description":"less plugin for StealJS and SystemJS",
-	"main":"css.js",
-	"scripts":{
-		"test": "grunt test"
-	},
-	"repository":{
-		"type":"git",
-		"url":"https://github.com/stealjs/steal-less.git"
-	},
-	"keywords":[
-		"StealJS",
-		"SystemJS",
-		"LESS"
-	],
-	"author":"Bitovi",
-	"license":"MIT",
-	"bugs":{
-		"url":"https://github.com/stealjs/steal-less/issues"
-	},
-	"homepage":"https://github.com/stealjs/steal-less",
-	"dependencies": {
-		"less": "2.4.0 - 2.5.3"
-	},
-	"devDependencies":{
-		"bower":"^1.4.1",
-		"grunt": "^0.4.5",
-		"steal":"^0.15.0",
-		"testee": "^0.2.5",
-		"steal-css": "^0.0.2",
-		"systemjs":"bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542"
-	},
-	"system": {
-	    "npmAlgorithm": "flat",
-	    "npmIgnore": [
-	      "testee", "grunt"
-	    ]
-	}
+  "name": "steal-less",
+  "version": "0.2.2",
+  "description": "less plugin for StealJS and SystemJS",
+  "main": "less.js",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stealjs/steal-less.git"
+  },
+  "keywords": [
+    "StealJS",
+    "SystemJS",
+    "LESS"
+  ],
+  "author": "Bitovi",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/stealjs/steal-less/issues"
+  },
+  "homepage": "https://github.com/stealjs/steal-less",
+  "dependencies": {
+    "less": "2.4.0 - 2.5.3"
+  },
+  "devDependencies": {
+    "bower": "^1.4.1",
+    "grunt": "^0.4.5",
+    "steal": "^0.15.0",
+    "steal-css": "^0.0.2",
+    "steal-qunit": "^0.1.1",
+    "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
+    "testee": "^0.2.5"
+  },
+  "system": {
+    "npmAlgorithm": "flat",
+    "npmIgnore": [
+      "testee",
+      "grunt"
+    ]
+  }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,39 @@
+var steal = require("@steal");
+var global = require("@loader").global;
+global.LESS_SOURCES = {};
+
+module.exports = function(loader){
+	var oldFetch, oldLessLoad;
+	var sources = {};
+
+	var overrideFetch = function() {
+		oldFetch = loader.fetch;
+		loader.fetch = function(load){
+			if(sources[load.name]) {
+				return Promise.resolve(sources[load.name]);
+			}
+			return oldFetch.apply(this, arguments);
+		};
+		overrideFetch = function(){};
+	};
+
+	return {
+		mock: function(){
+			return Promise.resolve();;
+		},
+		provide: function(name, source){
+			overrideFetch();
+			sources[name] = source;
+		},
+		provideLess: function(relPath, source){
+			global.LESS_SOURCES[relPath] = source;
+		},
+		restore: function(){
+			if(oldFetch) {
+				loader.fetch = oldFetch;
+			}
+			sources = {};
+			global.LESS_SOURCES = {};
+		}
+	};
+};

--- a/test/mock_less.js
+++ b/test/mock_less.js
@@ -1,0 +1,41 @@
+var plugin = require("steal-less");
+var steal = require("@steal");
+var loader = require("@loader");
+var global = loader.global;
+var StealLessManager = plugin.StealLessManager;
+
+function extend(a, b) {
+	for(var p in b) {
+		a[p] = b[p];
+	}
+	return a;
+}
+
+extend(exports, plugin);
+
+var loadFile = StealLessManager.prototype.loadFile;
+StealLessManager.prototype.loadFile = function(filename,
+											   currentDirectory,
+											   options, environment,
+											   callback){
+	var srces = global.LESS_SOURCES || {};
+	var src = srces[filename];
+	if(src) {
+		callback(null, {
+			contents: src,
+			filename: steal.joinURIs(currentDirectory, filename)
+		});
+		return;
+	}
+
+	return loadFile.apply(this, arguments);
+};
+
+exports.instantiate = function(load){
+	return {
+		deps: [],
+		execute: function(){
+			return loader.newModule({});
+		}
+	};
+};

--- a/test/unit.html
+++ b/test/unit.html
@@ -1,0 +1,9 @@
+<title>steal-less unit tests</title>
+<script>
+	steal = {
+		paths: {
+			"$less": "test/mock_less.js"
+		}
+	};
+</script>
+<script src="../node_modules/steal/steal.js" main="test/unit"></script>

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,0 +1,37 @@
+var loader = require("@loader");
+var helpers = require("./helpers")(loader);
+var QUnit = require("steal-qunit");
+
+QUnit.module("live-reload with deeply nested modules", {
+	setup: function(assert){
+		var done = assert.async();
+		helpers.mock().then(done, done);
+	},
+	teardown: function(){
+		helpers.restore();
+	}
+});
+
+QUnit.test("dependencies are in the includedModules", function(assert){
+	var done = assert.async();
+
+	helpers.provide("foo.less!$less", "@import './bar.less';");
+	helpers.provideLess("./bar.less", "@import './baz.less';");
+	helpers.provideLess("./baz.less", "body { background: green; }");
+
+	loader.import("foo.less")
+	.then(function(){
+		var load = loader.getModuleLoad("foo.less!$less");
+		var deps = load.metadata.includedDeps;
+
+		assert.ok(Array.isArray(deps), "got an array of deps");
+		assert.equal(deps.length, 2, "there are two nested deps");
+		assert.ok(/bar.less/.test(deps[0]), "first is bar.less");
+		assert.ok(/baz.less/.test(deps[1]), "second is baz.less");
+
+		done();
+	}, function(err){
+		assert.ok(!err, err && err.stack);
+		done(err);
+	});
+});


### PR DESCRIPTION
This adds the new property `includedDeps` to the load.metadata for each
less module. This is used to track dependencies that are included in the
module and not part of Steal's loading.

This is needed so that live-reload can handle includedDeps.