### PR TITLE
Don't use the fileCache when live-reloading

### DIFF
--- a/test/mock_less.js
+++ b/test/mock_less.js
@@ -13,22 +13,17 @@ function extend(a, b) {
 
 extend(exports, plugin);
 
-var loadFile = StealLessManager.prototype.loadFile;
-StealLessManager.prototype.loadFile = function(filename,
-											   currentDirectory,
-											   options, environment,
-											   callback){
-	var srces = global.LESS_SOURCES || {};
-	var src = srces[filename];
-	if(src) {
-		callback(null, {
-			contents: src,
-			filename: steal.joinURIs(currentDirectory, filename)
-		});
-		return;
+var doXHR = StealLessManager.prototype.doXHR;
+StealLessManager.prototype.doXHR = function(url, type, callback, errback) {
+	var sources = global.LESS_SOURCES || [], source;
+	for(var p in sources) {
+		source = sources[p];
+		if(source.exp.test(url)) {
+			callback(source.code, new Date());
+			return;
+		}
 	}
-
-	return loadFile.apply(this, arguments);
+	return doXHR.apply(this, arguments);
 };
 
 exports.instantiate = function(load){

--- a/test/unit.js
+++ b/test/unit.js
@@ -3,21 +3,19 @@ var helpers = require("./helpers")(loader);
 var QUnit = require("steal-qunit");
 
 QUnit.module("live-reload with deeply nested modules", {
-	setup: function(assert){
-		var done = assert.async();
-		helpers.mock().then(done, done);
-	},
 	teardown: function(){
 		helpers.restore();
+		loader.delete("foo.less!$less");
+		loader.delete("qux.less!$less");
 	}
 });
 
-QUnit.test("dependencies are in the includedModules", function(assert){
+QUnit.test("dependencies are in the includedDeps", function(assert){
 	var done = assert.async();
 
 	helpers.provide("foo.less!$less", "@import './bar.less';");
-	helpers.provideLess("./bar.less", "@import './baz.less';");
-	helpers.provideLess("./baz.less", "body { background: green; }");
+	helpers.provideLess("bar.less", "@import './baz.less';");
+	helpers.provideLess("baz.less", "body { background: green; }");
 
 	loader.import("foo.less")
 	.then(function(){
@@ -29,6 +27,62 @@ QUnit.test("dependencies are in the includedModules", function(assert){
 		assert.ok(/bar.less/.test(deps[0]), "first is bar.less");
 		assert.ok(/baz.less/.test(deps[1]), "second is baz.less");
 
+		done();
+	}, function(err){
+		assert.ok(!err, err && err.stack);
+		done(err);
+	});
+});
+
+QUnit.test("less fileCache is used if not live reloading", function(assert){
+	var done = assert.async();
+
+	helpers.provide("foo.less!$less", "@import './bar.less';");
+	helpers.provideLess("bar.less", "@import './baz.less';");
+	helpers.provideLess("baz.less", "body { background: green; }");
+
+	loader.import("foo.less")
+	.then(function(){
+		helpers.provide("qux.less!$less", "@import './bar.less';");
+		helpers.provideLess("baz.less", "body { background: red; }");
+
+		// Shim live-reload so the plugin thinks it's installed
+		helpers.mockLiveReload(false);
+
+		return loader.import("qux.less");
+	}).then(function(){
+		var load = loader.getModuleLoad("qux.less!$less");
+		var source = load.source;
+
+		assert.ok(/background\: green/.test(source), "got the correct source");
+		done();
+	}, function(err){
+		assert.ok(!err, err && err.stack);
+		done(err);
+	});
+});
+
+QUnit.test("less fileCache is not used if live reloading", function(assert){
+	var done = assert.async();
+
+	helpers.provide("foo.less!$less", "@import './bar.less';");
+	helpers.provideLess("bar.less", "@import './baz.less';");
+	helpers.provideLess("baz.less", "body { background: green; }");
+
+	loader.import("foo.less")
+	.then(function(){
+		helpers.provide("qux.less!$less", "@import './bar.less';");
+		helpers.provideLess("baz.less", "body { background: red; }");
+
+		// Shim live-reload so the plugin thinks it's installed
+		helpers.mockLiveReload(true);
+
+		return loader.import("qux.less");
+	}).then(function(){
+		var load = loader.getModuleLoad("qux.less!$less");
+		var source = load.source;
+
+		assert.ok(/background\: red/.test(source), "got the correct source");
 		done();
 	}, function(err){
 		assert.ok(!err, err && err.stack);


### PR DESCRIPTION
This changes it so that during a live-reload cycle the fileCache is not
used. This is so that we correctly re-import modules that have changed.