### PR TITLE
Make Steal and the Less File Manager share a common source for fetching

### DIFF
--- a/less.js
+++ b/less.js
@@ -9,6 +9,19 @@ var options = loader.lessOptions || {};
 // default optimization value.
 options.optimization |= lessEngine.optimization;
 
+// We store sources so files are only fetched once and shared between
+// Steal and the Less File Manager
+exports.fetch = function(load, fetch){
+	var p = getSource(load.address);
+	if(p) {
+		return p;
+	}
+
+	p = fetch.call(this, load);
+	addSource(load.address, p);
+	return p;
+};
+
 exports.translate = function(load) {
 	var address = load.address.replace(/^file\:/,"");
 	var useFileCache = true;
@@ -63,6 +76,8 @@ exports.translate = function(load) {
 		})
 		.then(renderLess, renderLess);
 	}
+
+	addSource(load.address, load.source);
 
 	return renderLess();
 };
@@ -125,6 +140,7 @@ if (lessEngine.FileManager) {
 			promise;
 
 		callback = function(err, file) {
+			addSource(file.filename, Promise.resolve(file.contents));
 			if (err) {
 				return _callback.call(self, err);
 			}
@@ -138,7 +154,8 @@ if (lessEngine.FileManager) {
 
 		promise = FileManager.prototype.loadFile.call(this, filename, currentDirectory, options, environment, callback);
 
-		// when promise is returned we must wrap promise, when one is not, the wrapped callback is used
+		// when promise is returned we must wrap promise, when one is not,
+		// the wrapped callback is used
 		if (promise && typeof promise.then == 'function') {
 			return promise.then(function(file) {
 				file._directory = directory;
@@ -146,6 +163,19 @@ if (lessEngine.FileManager) {
 				return self.parseFile(file);
 			});
 		}
+	};
+
+	var doXHR = StealLessManager.prototype.doXHR;
+	StealLessManager.prototype.doXHR = function(url, type, callback, errback){
+		var p = getSource(url);
+		if(p) {
+			return p.then(function(src){
+				callback(src, new Date());
+			}, function(err){
+				errback(err);
+			});
+		}
+		return doXHR.apply(this, arguments);
 	};
 
 	stealLessPlugin = {
@@ -156,6 +186,19 @@ if (lessEngine.FileManager) {
 
 	exports.StealLessManager = StealLessManager;
 }
+
+var getSource = function(url){
+	return loader._lessSources && loader._lessSources[url];
+}
+
+var addSource = function(url, p){
+	if(!loader._lessSources) {
+		loader._lessSources = {};
+	}
+	if(!loader._lessSources[url]) {
+		loader._lessSources[url] = Promise.resolve(p);
+	}
+};
 
 var normalizePath = function(path) {
 	var parts = path.split('/'),

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 var steal = require("@steal");
 var global = require("@loader").global;
 global.LESS_SOURCES = {};
+global.LESS_USED_SOURCES = [];
 
 module.exports = function(loader){
 	var oldFetch, oldLessLoad;
@@ -46,6 +47,7 @@ module.exports = function(loader){
 			}
 			sources = {};
 			global.LESS_SOURCES = {};
+			global.LESS_USED_SOURCES = [];
 			loader.delete("live-reload");
 			delete loader.liveReloadInstalled;
 		}

--- a/test/mock_less.js
+++ b/test/mock_less.js
@@ -19,6 +19,7 @@ StealLessManager.prototype.doXHR = function(url, type, callback, errback) {
 	for(var p in sources) {
 		source = sources[p];
 		if(source.exp.test(url)) {
+			global.LESS_USED_SOURCES.push(url);
 			callback(source.code, new Date());
 			return;
 		}
@@ -26,11 +27,12 @@ StealLessManager.prototype.doXHR = function(url, type, callback, errback) {
 	return doXHR.apply(this, arguments);
 };
 
+StealLessManager.usedSources = [];
+
 exports.instantiate = function(load){
-	return {
-		deps: [],
-		execute: function(){
-			return loader.newModule({});
-		}
+	load.metadata.format = 'less';
+	load.metadata.deps = [];
+	load.metadata.execute = function(){
+		return {};
 	};
 };


### PR DESCRIPTION
Since Steal and Less have their own separate fetching mechanism it means
they also have their own separate caching mechanisms. This change adds a
`.fetch` hook for Steal and a `.doXHR` hook for Less that share a common
cache, so if a resource has already been fetched in one it will not be
refetched in the other. Closes #18