### PR TITLE
When live-reloading, ignore local caching.

### DIFF
--- a/less.js
+++ b/less.js
@@ -12,6 +12,12 @@ options.optimization |= lessEngine.optimization;
 // We store sources so files are only fetched once and shared between
 // Steal and the Less File Manager
 exports.fetch = function(load, fetch){
+	var liveReload = loader.get("live-reload");
+	if(liveReload && liveReload.isReloading()) {
+		removeSource(load.address);
+		return fetch.apply(this, arguments);
+	}
+
 	var p = getSource(load.address);
 	if(p) {
 		return p;
@@ -197,6 +203,12 @@ var addSource = function(url, p){
 	}
 	if(!loader._lessSources[url]) {
 		loader._lessSources[url] = Promise.resolve(p);
+	}
+};
+
+var removeSource = function(url){
+	if(loader._lessSources) {
+		delete loader._lessSources[url];
 	}
 };
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,10 +11,21 @@ module.exports = function(loader){
 	var overrideFetch = mockedFetch = function () {
 		oldFetch = loader.fetch;
 		loader.fetch = function(load){
-			if(sources[load.name]) {
-				return Promise.resolve(sources[load.name]);
+			var lessPlugin = this.get("$less");
+			var lessPluginFetch = lessPlugin && lessPlugin["default"].fetch;
+
+			var fetch = function(){
+				if(sources[load.name]) {
+					return Promise.resolve(sources[load.name]);
+				}
+				return oldFetch.apply(this, arguments);
+			};
+
+			if(lessPluginFetch) {
+				return lessPluginFetch.call(this, load, fetch);
+			} else {
+				return fetch.call(this, load);
 			}
-			return oldFetch.apply(this, arguments);
 		};
 		overrideFetch = function(){};
 	};

--- a/test/unit.js
+++ b/test/unit.js
@@ -89,3 +89,31 @@ QUnit.test("less fileCache is not used if live reloading", function(assert){
 		done(err);
 	});
 });
+
+QUnit.test("steal-less' file cache is not used if live reloading", function(assert){
+	var done = assert.async();
+
+	helpers.provide("foo.less!$less", "body { background: green; }");
+
+	loader.import("foo.less")
+	.then(function(){
+		loader.delete("foo.less!$less");
+		helpers.provide("foo.less!$less", "body { background: red; }");
+
+		helpers.mockLiveReload(true);
+
+		return loader.import("foo.less");
+	})
+	.then(function(){
+		var load = loader.getModuleLoad("foo.less!$less");
+		var source = load.source;
+
+		assert.ok(/background\: red/.test(source), "got the correct source");
+		assert.ok(!loader._lessSources[load.address], "source not cached");
+		done();
+	}, function(err){
+		console.log("ARG", err);
+		assert.ok(!err, err & err.stack);
+		done(err);
+	});
+});


### PR DESCRIPTION
steal-less mantains a source cache in order to since less' caching with
steal' so that less files are only fetched once. When live-reloading we
need to ignore this cache so that we always go back to the server to
fetch the source.