### PR TITLE
Import and use plugins provided in lessOptions.plugins

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,8 @@
 System.config({
 	lessOptions: {
 		strictMath: true, // default false
-		dumpLineNumbers: "comments" // default false
+		dumpLineNumbers: "comments", // default false
+		plugins: ["less_plugins/plugin"]
 	},
 	paths: {
 		"bootstrap/*": "less_tilde/libs/bootstrap/*",

--- a/test/less_options/main.js
+++ b/test/less_options/main.js
@@ -4,10 +4,12 @@ if (typeof window !== "undefined" && window.QUnit) {
 	System.instantiate = function(load) {
 		if (load.name.indexOf("main.less") !== -1) {
 			var hasLineNumber = load.source.indexOf("line 1") !== -1,
-				hasStrictMath = load.source.indexOf("100%") !== -1;
+				hasStrictMath = load.source.indexOf("100%") !== -1,
+				hasPlugin = load.source.indexOf("/* steal-plugin-test */") !== -1;
 
 			QUnit.ok(hasLineNumber, "less set to dump line numbers");
 			QUnit.ok(hasStrictMath, "less set to process only maths inside un-necessary parenthesis");
+			QUnit.ok(hasPlugin, "less set to apply plugins");
 			QUnit.start();
 			removeMyself();
 		}

--- a/test/less_plugins/plugin.js
+++ b/test/less_plugins/plugin.js
@@ -1,0 +1,9 @@
+module.exports = {
+  install: function(less, pluginManager) {
+    pluginManager.addPostProcessor({
+      process: function(css) {
+        return '/* steal-plugin-test */\n' + css;
+      }
+    });
+  }
+}


### PR DESCRIPTION
This allows you to specify [plugins](http://lesscss.org/usage/#plugins) that will be imported and passed to the LessEngine.

I opted for setting up the plugin in a separate file to keep the config file cleaner.

**For example**, If I wanted to add the [`less-plugin-autoprefixer`](https://www.npmjs.com/package/less-plugin-autoprefix) I need to create a file in my project like:

```js
// src/steal/less/autoprefixer.js
const autoprefixPlugin = require('less-plugin-autoprefix'); 
const config = {
  browsers: ["last 2 versions"]
};
module.exports = new autoprefixPlugin(config);
```

And in my system config I just need to add this file to the `lessOptions.plugins` array:

```js
system: {
  ...
  lessOptions: {
    plugins: ["myproject/steal/less/autoprefixer"]
  }
}
```

