### PR TITLE
Upgrade to steal-css 1.2.0 and use $css

### DIFF
--- a/less.js
+++ b/less.js
@@ -1,4 +1,4 @@
-var css = require("steal-css");
+var css = require("$css");
 var loader = require("@loader");
 var lessEngine = require("./less-engine");
 

--- a/package.json
+++ b/package.json
@@ -23,15 +23,14 @@
   "homepage": "https://github.com/stealjs/steal-less",
   "dependencies": {
     "less": "2.4.0 - 2.5.3",
-    "steal-css": "^1.0.0"
+    "steal-css": "^1.2.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.6",
     "bower": "^1.4.1",
     "qunitjs": "^1.23.1",
-    "steal": "^1.0.0-rc.0",
-    "steal-css": "^1.0.0-rc.0",
-    "steal-qunit": "^0.1.1",
+    "steal": "^1.0.0",
+    "steal-qunit": "^1.0.0",
     "testee": "^0.2.5"
   },
   "steal": {

--- a/test/config.js
+++ b/test/config.js
@@ -7,6 +7,9 @@ System.config({
 	ext: {
 		less: "steal-less"
 	},
+	map: {
+		"$css": "steal-css"
+	},
 	paths: {
 		"bootstrap/*": "less_tilde/libs/bootstrap/*",
 		"img-pack/*": "less_tilde/libs/img-pack/*",

--- a/test/less_options/main.js
+++ b/test/less_options/main.js
@@ -16,5 +16,5 @@ if (typeof window !== "undefined" && window.QUnit) {
 		return systemInstantiate.apply(this, arguments);
 	};
 
-	steal("less_options/main.less!");
+	steal("less_options/main.less");
 }


### PR DESCRIPTION
steal-css 1.2.0 defines itself as the $css module. We want to start
using this as our import so that other css plugins can be used, like
done-css.

Fixes #44