### PR TITLE
Added a catch that logs the error

### DIFF
--- a/less.js
+++ b/less.js
@@ -109,7 +109,11 @@ exports.translate = function(load) {
 				useFileCache = false;
 			}
 		})
-		.then(renderLess, renderLess);
+		.then(renderLess, renderLess)
+		.catch(function(err) {
+			console.error(err.message + " in " + err.filename + ":" + err.line);
+			console.dir(err);
+		});
 	}
 
 	return renderLess();


### PR DESCRIPTION
If there is a LESS issue will console.error the error with filename and line number. The rest of live-reload still works and if the error in the LESS file is corrected it will properly get the styles for that file again with live-reload.

Closes https://github.com/donejs/donejs/issues/1054