### PR TITLE
Rolling back less dep to fix breaking error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/stealjs/steal-less",
   "dependencies": {
-    "less": "2.7.1",
+    "less": "2.4.0 - 2.5.3",
     "steal-css": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to fix an error after upgrading to `2.7.1` where LESS is compiled and rendered successfully at first but then the info message `Less has finished and no sheets were loaded.` appears in the console from line `861` of less.js and all elements cease to appear.