### PR TITLE
Resolve the filename path

### DIFF
--- a/less.js
+++ b/less.js
@@ -58,8 +58,13 @@ exports.translate = function(load) {
 	}
 
 	function renderLess() {
+		var filename = address;
+		if(loader._nodeRequire) {
+			filename = loader._nodeRequire("path").resolve(address);
+		}
+
 		var renderOptions = {
-			filename: address,
+			filename: filename,
 			useFileCache: useFileCache
 		};
 		var pluginPromises = [];


### PR DESCRIPTION
This fixes https://github.com/stealjs/steal-less/issues/67 and https://github.com/stealjs/steal-tools/issues/1009

Less expects a file system path, not a URL. Calling path.resolve() fixes
this issue.