### PR TITLE
update less.js dependency to get fix for reference imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/stealjs/steal-less",
   "dependencies": {
-    "less": "2.6.0",
+    "less": "2.4.0 - 2.6.0",
     "steal-css": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/stealjs/steal-less",
   "dependencies": {
-    "less": "2.4.0 - 2.5.3",
+    "less": "2.6.0",
     "steal-css": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Less 2.6.0 contains a fix for reference imports. In previous implementations these were buggy and didn't operate as the less docs indicated. This is a very useful feature for avoiding global LESS styles being inserted into your component stylesheets. 

I've tested this in a large scale app and it resolves the issue I was seeing with Less.js 2.5.3. Additionally it doesn't appear to produce the bug noted here https://github.com/stealjs/steal-less/pull/61