### PR TITLE
Make less use async mode in the browser

### DIFF
--- a/less-engine.js
+++ b/less-engine.js
@@ -1,1 +1,5 @@
+// Without these options Less will inject a `body { display: none !important; }`
+var less = window.less || (window.less = {});
+less.async = true;
+
 module.exports = require("less/dist/less");


### PR DESCRIPTION
This makes less use async mode in the browser. We were already doing
this for our less requests, but now we also set it before less executes,
otherwise it tries to do some weird display: none stuff.  Fixes https://github.com/donejs/donejs/issues/1113