### PR TITLE
Add a super-dependency to less

### DIFF
--- a/less-config.js
+++ b/less-config.js
@@ -1,0 +1,6 @@
+// Without these options Less will inject a `body { display: none !important; }`
+"format cjs";
+
+var global = System.global;
+var less = global.less || (global.less = {});
+less.async = true;

--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
     },
     "ext": {
       "less": "steal-less"
+    },
+    "meta": {
+      "less/dist/less": {
+        "format": "global",
+        "deps": ["steal-less/less-config"]
+      }
     }
   },
   "bit-docs": {


### PR DESCRIPTION
This configures less with `async: true` which is needed to disable the
`display: none` behavior it does. We do this by making less a global and
then adding a dependency to it.