### PR TITLE
Run tests with latest steal@1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-bower_components/
 node_modules/**
 doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "5.8"
+  - 8
+  - node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "bower": "^1.4.1",
     "qunitjs": "^1.23.1",
-    "steal": "^1.0.0",
+    "steal": "^1.12.6",
     "steal-qunit": "^1.0.0",
-    "testee": "^0.3.0"
+    "testee": "^0.8.1"
   },
   "steal": {
     "plugins": [
@@ -70,7 +69,9 @@
     "meta": {
       "less/dist/less": {
         "format": "global",
-        "deps": ["steal-less/less-config"]
+        "deps": [
+          "steal-less/less-config"
+        ]
       }
     }
   },

--- a/test/less_error/dev.html
+++ b/test/less_error/dev.html
@@ -1,30 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.assert = window.parent.assert;
+		window.done = window.parent.done;
 	</script>
-
+	
 	<script src="../../node_modules/steal/steal.js"
 		data-config="../config.js">
 	</script>
 
 	<script>
 		System['import']('less_error/main').then(function(){
-			if(window.QUnit) {
-				QUnit.ok(false, "Should not have loaded");
-				QUnit.start();
-				removeMyself();
+			if(window.assert) {
+				assert.ok(false, "Should not have loaded");
+				done();
 			} else {
 				console.log("Should not have loaded");
 			}
 		}, function(err){
-			if (!window.QUnit) {
+			if (!window.assert) {
 				console.error(err);
 			} else {
-				QUnit.ok(/not-exists\.less/.test(err.message), "Message contains code snippet to the missing stylesheet.");
-				QUnit.start();
-				removeMyself();
+				assert.ok(/not-exists\.less/.test(err.message), "Message contains code snippet to the missing stylesheet.");
 			}
+			done();
 		});
 	</script>
 </body>
+</html>

--- a/test/less_imports/dev.html
+++ b/test/less_imports/dev.html
@@ -1,7 +1,7 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.assert = window.parent.assert;
+		window.done = window.parent.done;
 	</script>
 
 	<script type="text/javascript"
@@ -11,17 +11,16 @@
 
 	<script>
 		System['import']('less_imports/main').then(function(){
-			QUnit.ok(true, "was able to load");
-			QUnit.start();
-			removeMyself();
-		}, function(){
-			if (!window.QUnit) {
+			assert.ok(true, "was able to load");
+			done();
+		}, function(err){
+			console.log(err);
+			if (!window.assert) {
 				console.log("borked");
 			} else {
-				QUnit.ok(false, "was unable to load");
-				QUnit.start();
-				removeMyself();
+				assert.ok(false, "was unable to load");
 			}
+			done();
 		});
 	</script>
 </body>

--- a/test/less_options/main.js
+++ b/test/less_options/main.js
@@ -1,4 +1,4 @@
-if (typeof window !== "undefined" && window.QUnit) {
+if (typeof window !== "undefined" && window.assert) {
 	var systemInstantiate = System.instantiate;
 
 	System.instantiate = function(load) {
@@ -7,11 +7,10 @@ if (typeof window !== "undefined" && window.QUnit) {
 				hasStrictMath = load.source.indexOf("100%") !== -1,
 				hasPlugin = load.source.indexOf("/* steal-plugin-test */") !== -1;
 
-			QUnit.ok(hasLineNumber, "less set to dump line numbers");
-			QUnit.ok(hasStrictMath, "less set to process only maths inside un-necessary parenthesis");
-			QUnit.ok(hasPlugin, "less set to apply plugins");
-			QUnit.start();
-			removeMyself();
+			assert.ok(hasLineNumber, "less set to dump line numbers");
+			assert.ok(hasStrictMath, "less set to process only maths inside un-necessary parenthesis");
+			assert.ok(hasPlugin, "less set to apply plugins");
+			done();
 		}
 		return systemInstantiate.apply(this, arguments);
 	};

--- a/test/less_options/site.html
+++ b/test/less_options/site.html
@@ -1,7 +1,7 @@
 <body>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.assert = window.parent.assert;
+		window.done = window.parent.done;
 	</script>
 	<script type="text/javascript"
 		src="../../node_modules/steal/steal.js"

--- a/test/less_tilde/dev.html
+++ b/test/less_tilde/dev.html
@@ -1,8 +1,8 @@
 <body>
 	<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
 	<script>
-		window.QUnit = window.parent.QUnit;
-		window.removeMyself = window.parent.removeMyself;
+		window.assert = window.parent.assert;
+		window.done = window.parent.done;
 	</script>
 	<div id='test-element'>ELMENT1</div>
 	<div id='test-element-2'>ELMENT2</div>

--- a/test/less_tilde/main.js
+++ b/test/less_tilde/main.js
@@ -1,6 +1,5 @@
 import "less_tilde/module_a.less!";
 
-
 var testImage = function(selector, cb){
 	var image = new Image();
 	image.onload = function(){
@@ -8,42 +7,38 @@ var testImage = function(selector, cb){
 	};
 	image.onerror = function(){
 		cb(selector);
-		QUnit.ok(false, "image not loaded");
-		removeMyself();
+		assert.ok(false, "image not loaded");
+		done();
 	};
 	image.src = $(selector).css("background-image").replace(/url\("?/,"").replace(/"?\)/,"");
 };
 
-
-if(window.QUnit) {
-	QUnit.equal( $("#test-element").width(), 20, 'applied mixin-b');
-	QUnit.equal( $("#test-element").height(), 20), 'applied mixin-c';
-	QUnit.equal( $('#test-element-4').width(), 1337, 'locate://\'ed resource from importer whose path includes "../"');
+if (window.assert) {
+	assert.equal( $("#test-element").width(), 20, 'applied mixin-b');
+	assert.equal( $("#test-element").height(), 20, 'applied mixin-c' );
+	assert.equal( $('#test-element-4').width(), 1337, 'locate://\'ed resource from importer whose path includes "../"');
 
 	testImage("#test-element", function(err){
 		if(err){
-			QUnit.ok(false, err);
-			QUnit.start();
-			removeMyself();
+			assert.ok(false, err);
+			done();
 		} else {
-			QUnit.ok(true, "#test-relative");
+			assert.ok(true, "#test-relative");
 			testImage("#test-element-2", function(err){
 				if(err){
-					QUnit.ok(false, err);
-					QUnit.start();
-					removeMyself();
+					assert.ok(false, err);
+					done();
 				} else {
-					QUnit.ok(true, "#test-element-2, variable strings with locate://");
+					assert.ok(true, "#test-element-2, variable strings with locate://");
 					testImage("#test-element-3", function(err){
 						if(err){
-							QUnit.ok(false, err + ' background image didn\'t load');
-							removeMyself();
+							assert.ok(false, err + ' background image didn\'t load');
+							done();
 						} else {
-							QUnit.ok(true, "#test-element-3, imported variable strings with locate://");
+							assert.ok(true, "#test-element-3, imported variable strings with locate://");
 						}
 
-						QUnit.start();
-						removeMyself();
+						done();
 					});
 				}
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -1,30 +1,34 @@
-QUnit.module("steal-less plugin");
-var asyncTest = QUnit.asyncTest;
 
-var makeIframe = function(src){
-	var iframe = document.createElement('iframe');
-	window.removeMyself = function(){
-		delete window.removeMyself;
+function makeIframe(src, assert) {
+	var done = assert.async();
+	var iframe = document.createElement("iframe");
+
+	window.assert = assert;
+	window.done = function() {
+		done();
 		document.body.removeChild(iframe);
 	};
+
 	document.body.appendChild(iframe);
 	iframe.src = src;
-};
+}
 
-asyncTest("set options to less plugin", function(){
-	makeIframe("less_options/site.html");
+QUnit.module("steal-less plugin");
+
+QUnit.test("set options to less plugin", function(assert) {
+	makeIframe("less_options/site.html", assert);
 });
 
-asyncTest("less loads in the right spot", function(){
-	makeIframe("less_imports/dev.html");
+QUnit.test("less loads in the right spot", function(assert) {
+	makeIframe("less_imports/dev.html", assert);
 });
 
-asyncTest("less loads imports that include locate:// paths", function(){
-	makeIframe("less_tilde/dev.html");
+QUnit.test("less loads imports that include locate:// paths", function(assert) {
+	makeIframe("less_tilde/dev.html", assert);
 });
 
-asyncTest("Get good error messages on 404s", function() {
-	makeIframe("less_error/dev.html");
-})
+QUnit.test("Get good error messages on 404s", function(assert) {
+	makeIframe("less_error/dev.html", assert);
+});
 
 QUnit.start();


### PR DESCRIPTION
Closes #70 

- Upgrade tests to fix a silent rejection thrown by testee, it seems
  to dislike the way QUnit was set up. We are no longer using asyncTest,
  or QUnit.start/stop. Instead we are using the assert.async() API

- Upgrade testee to get the latests bug fixes

Instead of 

![screen shot 2019-01-10 at 9 42 58 am](https://user-images.githubusercontent.com/724877/50987108-df5c6d00-14c5-11e9-85a6-01351c07bab1.png)

the output now looks like:

![screen shot 2019-01-10 at 9 43 30 am](https://user-images.githubusercontent.com/724877/50987121-e8e5d500-14c5-11e9-8fa5-2359e1ae0888.png)


In the browser I cannot get the tests to fail, but for some reason through testee sometimes some of the tests just hang... Pushing the PR to take a look at the CI output. 